### PR TITLE
CORS and time

### DIFF
--- a/pydap/responses/wms/__init__.py
+++ b/pydap/responses/wms/__init__.py
@@ -135,6 +135,7 @@ class WMSResponse(BaseResponse):
         if type_ == 'GetCapabilities':
             self.serialize = self._get_capabilities(environ)
             self.headers.append( ('Content-type', 'text/xml') )
+            self.headers.append( ('Access-Control-Allow-Origin', '*') )
         elif type_ == 'GetMap':
             self.serialize = self._get_map(environ)
             self.headers.append( ('Content-type', 'image/png') )

--- a/pydap/responses/wms/__init__.py
+++ b/pydap/responses/wms/__init__.py
@@ -204,7 +204,7 @@ class WMSResponse(BaseResponse):
         dpi = float(environ.get('pydap.responses.wms.dpi', 80))
         w = float(query.get('WIDTH', 256))
         h = float(query.get('HEIGHT', 256))
-        time = query.get('time')
+        time = query.get('TIME')
         figsize = w/dpi, h/dpi
         bbox = [float(v) for v in query.get('BBOX', '-180,-90,180,90').split(',')]
         cmap = query.get('cmap', environ.get('pydap.responses.wms.cmap', 'jet'))
@@ -256,7 +256,7 @@ class WMSResponse(BaseResponse):
                     end = iso8601.parse_date(end, default_timezone=None)
                     l[(values >= start) & (values <= end)] = True
                 else:
-                    instant = iso8601.parse_date(token.strip(), default_timezone=None)
+                    instant = iso8601.parse_date(token.strip().rstrip('Z'), default_timezone=None)
                     l[values == instant] = True
         else:
             l = None


### PR DESCRIPTION
Hi Rob,

Here are a few very small suggestions for the PYDAP WMS response.

The first is to include a header for Cross-Origin Resource Sharing. I am not entirely sure whether some of the CORS preflight related headers should be set as well.

The second is to use upper letters for the "TIME" query string input (which it should be according to the standard as far as I can see). But maybe it should be done in a backwards compatible way instead so that both upper and lower cases are acceptable.

The third is to strip a trailing "Z" from timestamps in the requested time string since that format is also allowed by the standard.

Hope you can use some of the suggestions. Btw. this is the first time I use the Github pull request feature so I hope that I do it right.

Best regards,
Jesper
