### PR TITLE
Paletted PNG output

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -56,6 +56,7 @@ scratch. This response enables Pydap to serve data as a WMS server.
             'matplotlib',
             'coards',
             'iso8601',
+            'Pillow',
         ],
         entry_points="""
             [pydap.response]

--- a/pydap/responses/wms/__init__.py
+++ b/pydap/responses/wms/__init__.py
@@ -19,6 +19,7 @@ rcParams['xtick.labelsize'] = 'small'
 rcParams['ytick.labelsize'] = 'small'
 import iso8601
 import coards
+from PIL import Image
 
 from pydap.model import *
 from pydap.responses.lib import BaseResponse
@@ -233,7 +234,28 @@ class WMSResponse(BaseResponse):
             ax.axis('off')
             canvas = FigureCanvas(fig)
             output = StringIO() 
-            canvas.print_png(output)
+            # Optionally convert to paletted png
+            paletted = bool(environ.get('pydap.responses.wms.paletted', False))
+            if paletted:
+                # Read image
+                buf, size = canvas.print_to_buffer()
+                im = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
+                # Find number of colors
+                ncolors = len(im.getcolors())
+                # Get alpha band
+                alpha = im.split()[-1]
+                # Convert to paletted image
+                im = im.convert("RGB")
+                im = im.convert("P", palette=Image.ADAPTIVE, colors=ncolors)
+                # Set all pixel values below ncolors to 1 and the rest to 0
+                mask = Image.eval(alpha, lambda a: 255 if a <=128 else 0)
+                # Paste the color of index ncolors and use alpha as a mask
+                im.paste(ncolors, mask)
+                # Truncate palette to actual size to save space
+                im.palette.palette = im.palette.palette[:3*(ncolors+1)]
+                im.save(output, 'png', optimize=False, transparency=ncolors)
+            else:
+                canvas.print_png(output)
             if hasattr(dataset, 'close'): dataset.close()
             return [ output.getvalue() ]
         return serialize

--- a/pydap/responses/wms/__init__.py
+++ b/pydap/responses/wms/__init__.py
@@ -242,18 +242,22 @@ class WMSResponse(BaseResponse):
                 im = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
                 # Find number of colors
                 ncolors = len(im.getcolors())
-                # Get alpha band
-                alpha = im.split()[-1]
-                # Convert to paletted image
-                im = im.convert("RGB")
-                im = im.convert("P", palette=Image.ADAPTIVE, colors=ncolors)
-                # Set all pixel values below ncolors to 1 and the rest to 0
-                mask = Image.eval(alpha, lambda a: 255 if a <=128 else 0)
-                # Paste the color of index ncolors and use alpha as a mask
-                im.paste(ncolors, mask)
-                # Truncate palette to actual size to save space
-                im.palette.palette = im.palette.palette[:3*(ncolors+1)]
-                im.save(output, 'png', optimize=False, transparency=ncolors)
+                # Only convert if the number of colors is less than 256
+                if ncolors <= 256:
+                    # Get alpha band
+                    alpha = im.split()[-1]
+                    # Convert to paletted image
+                    im = im.convert("RGB")
+                    im = im.convert("P", palette=Image.ADAPTIVE, colors=ncolors)
+                    # Set all pixel values below ncolors to 1 and the rest to 0
+                    mask = Image.eval(alpha, lambda a: 255 if a <=128 else 0)
+                    # Paste the color of index ncolors and use alpha as a mask
+                    im.paste(ncolors, mask)
+                    # Truncate palette to actual size to save space
+                    im.palette.palette = im.palette.palette[:3*(ncolors+1)]
+                    im.save(output, 'png', optimize=False, transparency=ncolors)
+                else:
+                    canvas.print_png(output)
             else:
                 canvas.print_png(output)
             if hasattr(dataset, 'close'): dataset.close()

--- a/pydap/responses/wms/__init__.py
+++ b/pydap/responses/wms/__init__.py
@@ -235,7 +235,7 @@ class WMSResponse(BaseResponse):
             canvas = FigureCanvas(fig)
             output = StringIO() 
             # Optionally convert to paletted png
-            paletted = bool(environ.get('pydap.responses.wms.paletted', False))
+            paletted = asbool(environ.get('pydap.responses.wms.paletted', 'false'))
             if paletted:
                 # Read image
                 buf, size = canvas.print_to_buffer()

--- a/pydap/responses/wms/__init__.py
+++ b/pydap/responses/wms/__init__.py
@@ -22,7 +22,7 @@ import coards
 try:
     from PIL import Image
 except:
-    pass
+    PIL = None
 
 from pydap.model import *
 from pydap.responses.lib import BaseResponse
@@ -244,9 +244,10 @@ class WMSResponse(BaseResponse):
                 buf, size = canvas.print_to_buffer()
                 im = Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
                 # Find number of colors
-                ncolors = len(im.getcolors())
+                colors = im.getcolors(256)
                 # Only convert if the number of colors is less than 256
-                if ncolors <= 256:
+                if colors is not None:
+                    ncolors = len(colors)
                     # Get alpha band
                     alpha = im.split()[-1]
                     # Convert to paletted image

--- a/pydap/responses/wms/__init__.py
+++ b/pydap/responses/wms/__init__.py
@@ -19,7 +19,10 @@ rcParams['xtick.labelsize'] = 'small'
 rcParams['ytick.labelsize'] = 'small'
 import iso8601
 import coards
-from PIL import Image
+try:
+    from PIL import Image
+except:
+    pass
 
 from pydap.model import *
 from pydap.responses.lib import BaseResponse


### PR DESCRIPTION
Hi Rob,

I have made an option to convert the resulting PNG to a paletted PNG. The conversion is only done when the option is enabled and when the number of colors in the plot is <= 256. I have tested the conversion against the coads.nc example file (and our own files) using this script:

http://pastebin.com/ZnXSSaJw

You should be able to run this yourself. Just run the script from a directory where you have coads.nc (the script will store some pngs in this directory). On our server I get the following results:

$ python test_paletted_png.py
Timing png generation. Please be patient...
Average cost of paletting one png: 23.85 milliseconds
Total size reduced from 102688 to 58788 (42.8 %)

It depends on the specific use case whether such a conversion makes sense (whether the extra time it takes to do the paletting outweighs the time saved transmitting the image - taking into account that the same image can be cached and sent to multiple users). For our purposes we definitely expect it to be worth the extra CPU time. Especially for quiver plots (which I have an unfinished test implementation of - I will of course submit it so that you can decide whether you want it as well when it is more polished). But your mileage might vary (which is also why it should IMO be optional).

One assumption of this conversion is that we only have GIF-style transparency. One pixel is either fully transparent or fully opaque. But that is of course also the case for the plots that are produced.

Best regards,
Jesper
